### PR TITLE
Add ability to specify a recent time range

### DIFF
--- a/cti-stats
+++ b/cti-stats
@@ -44,6 +44,7 @@ Options:
     -s USE_SSL --use-ssl=USE_SSL            Use SSL? [default: yes]
     -v VALIDATE --validate-cert=VALIDATE    Attempt SSL cert validation? [default: yes]
     -t TARGET_DIR --target-dir=TARGET_DIR   Specify target directory containing CTI
+    -r RANGE --time-range=RANGE             Specify a recent time range for polling in seconds (1 day = 86400)
     -q --quiet                              Run silently (no progressbar)
     -H --help                               Show this screen.
     -V --version                            Show version.
@@ -67,6 +68,7 @@ def main():
                                                            args['--passwd'],
                                                            args['--use-ssl'],
                                                            args['--validate-cert'],
+                                                           args['--time-range'],
                                                            args['--quiet'])
     elif args['--file-stats']:
         (cooked_stix_objs, cooked_cybox_objs) = dir_walk(args['--target-dir'],

--- a/lib/cti.py
+++ b/lib/cti.py
@@ -82,7 +82,7 @@ def process_stix_pkg(stix_package):
     return(raw_stix_objs, raw_cybox_objs)
 
 
-def taxii_poll(host=None, port=None, endpoint=None, collection=None, user=None, passwd=None, use_ssl=None, attempt_validation=None, quiet=None):
+def taxii_poll(host=None, port=None, endpoint=None, collection=None, user=None, passwd=None, use_ssl=None, attempt_validation=None, time_range=None, quiet=None):
     '''poll cti via taxii'''
     client = tc.HttpClient()
     client.setUseHttps(use_ssl)
@@ -95,7 +95,7 @@ def taxii_poll(host=None, port=None, endpoint=None, collection=None, user=None, 
                         'indicators': set(), 'threat_actors': set(), \
                         'ttps': set()}
     cooked_cybox_objs = dict()
-    earliest = poll_start()
+    earliest = poll_start(time_range)
     latest = nowutc()
     poll_window = 43200 # 12 hour blocks seem reasonable
     total_windows = (latest - earliest) / poll_window

--- a/lib/util.py
+++ b/lib/util.py
@@ -26,7 +26,6 @@ import pytz
 import os
 import fnmatch
 
-
 def nowutc():
     '''utc now'''
     return int(time.mktime(datetime.datetime.utcnow().replace(tzinfo=pytz.utc).timetuple()))
@@ -37,12 +36,16 @@ def epoch_start():
     return datetime.datetime.utcfromtimestamp(0).replace(tzinfo=pytz.utc)
 
 
-def poll_start():
-    '''for an all-time poll, rather than starting at the epoch start,
-    given that the STIX 1.0 release was tagged on Github 10.04.2013,
-    assuming a start time of 01.01.2013 seems reasonable'''
-    timestamp = datetime.datetime.strptime('01.01.2013 00:00:00 UTC', '%d.%m.%Y %H:%M:%S %Z')
-    return int(time.mktime(timestamp.timetuple()))
+def poll_start(timerange=None):
+    timestamp = None
+    if timerange is None:
+        '''for an all-time poll, rather than starting at the epoch start,
+        given that the STIX 1.0 release was tagged on Github 10.04.2013,
+        assuming a start time of 01.01.2013 seems reasonable'''
+        timestamp = datetime.datetime.strptime('01.01.2013 00:00:00 UTC', '%d.%m.%Y %H:%M:%S %Z')
+        return int(time.mktime(timestamp.timetuple()))
+    else:
+        return int(time.time()) - int(timerange)
 
 
 def find_files(pattern, top):


### PR DESCRIPTION
Add ability to specify a recent time range. When you know a server only has 48 hours of data, this makes the command take seconds/minutes instead of hours.